### PR TITLE
Resolve out of order operations on Node 12.6.0

### DIFF
--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -186,7 +186,7 @@ export class Http2CallStream extends Duplex implements Call {
     }
     this.isReadFilterPending = true;
     this.filterStack
-      .receiveMessage(framedMessage)
+      .receiveMessage((async () => framedMessage)())
       .then(
         this.handleFilteredRead.bind(this),
         this.handleFilterError.bind(this)

--- a/packages/grpc-js/src/call-stream.ts
+++ b/packages/grpc-js/src/call-stream.ts
@@ -186,7 +186,7 @@ export class Http2CallStream extends Duplex implements Call {
     }
     this.isReadFilterPending = true;
     this.filterStack
-      .receiveMessage(Promise.resolve(framedMessage))
+      .receiveMessage(framedMessage)
       .then(
         this.handleFilteredRead.bind(this),
         this.handleFilterError.bind(this)


### PR DESCRIPTION
In Node 12.6.0 there appears to be an additional tick incurred which allows this.finalStatus to be set before handleFilteredRead() can process the message. Removing this unnecessary Promise allows handleFilteredRead() to process the message and call  before this.finalStatus is set.